### PR TITLE
feat: Implement de-duplication in import-history

### DIFF
--- a/cmd/importhistory.go
+++ b/cmd/importhistory.go
@@ -59,6 +59,7 @@ func runImportHistory(cmd *cobra.Command, args []string) error {
 
 	scanner := bufio.NewScanner(file)
 	importedCount := 0
+	skippedCount := 0
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -101,11 +102,15 @@ func runImportHistory(cmd *cobra.Command, args []string) error {
 		tty := ""    // Not available from zsh history
 		sid := ""    // Not available from zsh history
 
-		_, err := manager.AddCommand(commandText, directory, tty, sid, hostname, username, timestamp, true)
+		skipped, err := manager.AddCommand(commandText, directory, tty, sid, hostname, username, timestamp, false)
 		if err != nil {
 			log.Printf("Failed to import command: \"%s\": %v", commandText, err)
 		} else {
-			importedCount++
+			if skipped {
+				skippedCount++
+			} else {
+				importedCount++
+			}
 		}
 	}
 
@@ -113,6 +118,6 @@ func runImportHistory(cmd *cobra.Command, args []string) error {
 		log.Printf("Error reading history file: %v", err)
 	}
 
-	fmt.Printf("Imported %d commands from %s\n", importedCount, historyFilePath)
+	fmt.Printf("Imported %d commands and skipped %d duplicate commands from %s\n", importedCount, skippedCount, historyFilePath)
 	return nil
 }


### PR DESCRIPTION
This commit introduces de-duplication functionality to the `import-history` subcommand. Duplicate commands from your Zsh history file will now be skipped during the import process.

The following changes were made:
- Modified `cmd/importhistory.go` to leverage the existing de-duplication logic in `internal/history/manager.go` by passing `false` for the `noDedup` parameter in the `AddCommand` call.
- Added a counter to track the number of skipped duplicate commands.
- Updated the import success message to display both the number of imported commands and the number of skipped duplicate commands.
- Updated tests in `cmd/importhistory_test.go` to verify the new de-duplication behavior, including a new test case specifically for various de-duplication scenarios.

All tests passed successfully.