### PR TITLE
feat: Add index to command column in history table

### DIFF
--- a/internal/embedded/migrations/0004_add_index_to_command.down.sql
+++ b/internal/embedded/migrations/0004_add_index_to_command.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_history_command;

--- a/internal/embedded/migrations/0004_add_index_to_command.up.sql
+++ b/internal/embedded/migrations/0004_add_index_to_command.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_history_command ON history (command);


### PR DESCRIPTION
This commit introduces a new database migration to add an index to the `command` column in the `history` table.

The index is added to improve performance during duplicate checks, particularly for the `history-import` subcommand, which you reported to be slow.

The migration includes:
- `0004_add_index_to_command.up.sql`: Creates the index `idx_history_command`.
- `0004_add_index_to_command.down.sql`: Drops the index `idx_history_command`.

The schema migration command (`schema-migrate`) was successfully run to apply and verify this change, bringing the schema to version 4.