### PR TITLE
feat: Implement KQL-like search functionality

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -80,7 +80,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// Create help text view
 	helpText := tview.NewTextView().
-		SetText("TAB: cd & cmd    ENTER: cmd    ESC: exit").
+		SetText("ESC: exit | ENTER: cmd | TAB: cd & cmd | KQL: term cmd:mycmd dir:/path host:host").
 		SetTextAlign(tview.AlignCenter)
 
 	// Set table headers

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
+github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/history/manager_test.go
+++ b/internal/history/manager_test.go
@@ -142,3 +142,191 @@ func TestSchemaVersionCheck(t *testing.T) {
 		}
 	})
 }
+
+func TestHistoryQuery_Search_KQL(t *testing.T) {
+	// Helper function to compare string slices
+	compareStringSlices := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Helper function to compare interface slices
+	compareInterfaceSlices := func(a, b []interface{}) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if fmt.Sprintf("%v", a[i]) != fmt.Sprintf("%v", b[i]) {
+				return false
+			}
+		}
+		return true
+	}
+
+	tests := []struct {
+		name              string
+		query             string
+		expectedConditions []string
+		expectedArgs      []interface{}
+		expectParseError  bool
+	}{
+		{
+			name:              "simple term",
+			query:             "my query",
+			expectedConditions: []string{"command LIKE ?"},
+			expectedArgs:      []interface{}{"%my query%"},
+		},
+		{
+			name:              "command field",
+			query:             "command:my_command",
+			expectedConditions: []string{"command LIKE ?"},
+			expectedArgs:      []interface{}{"%my_command%"},
+		},
+		{
+			name:              "dir field",
+			query:             "dir:/some/path",
+			expectedConditions: []string{"executing_dir LIKE ?"},
+			expectedArgs:      []interface{}{"%/some/path%"},
+		},
+		{
+			name:              "directory field",
+			query:             "directory:/another/path",
+			expectedConditions: []string{"executing_dir LIKE ?"},
+			expectedArgs:      []interface{}{"%/another/path%"},
+		},
+		{
+			name:              "host field",
+			query:             "host:my_hostname",
+			expectedConditions: []string{"executing_host LIKE ?"},
+			expectedArgs:      []interface{}{"%my_hostname%"},
+		},
+		{
+			name:              "hostname field",
+			query:             "hostname:other_host",
+			expectedConditions: []string{"executing_host LIKE ?"},
+			expectedArgs:      []interface{}{"%other_host%"},
+		},
+		{
+			name:  "combination of terms",
+			query: "term1 command:cmd_term dir:/d hostname:h",
+			expectedConditions: []string{
+				"command LIKE ?",
+				"command LIKE ?",
+				"executing_dir LIKE ?",
+				"executing_host LIKE ?",
+			},
+			expectedArgs: []interface{}{
+				"%term1%",
+				"%cmd_term%",
+				"%/d%",
+				"%h%",
+			},
+		},
+		{
+			name:              "quoted simple term",
+			query:             `"my command with spaces"`,
+			expectedConditions: []string{"command LIKE ?"},
+			expectedArgs:      []interface{}{"%my command with spaces%"},
+		},
+		{
+			name:              "parsing error fallback",
+			query:             "command: value_without_quotes_or_colon_after_field",
+			expectedConditions: []string{"command LIKE ?"},
+			expectedArgs:      []interface{}{"%command: value_without_quotes_or_colon_after_field%"},
+			expectParseError:  true,
+		},
+		{
+			name:              "empty query",
+			query:             "",
+			expectedConditions: nil, // Or []string{} depending on initialization
+			expectedArgs:      nil, // Or []interface{}{}
+		},
+		{
+			name:  "term with colon not as field",
+			query: "term:with:colon",
+			expectedConditions: []string{"command LIKE ?"},
+			expectedArgs:      []interface{}{"%term:with:colon%"},
+		},
+		{
+			name:  "field then simple term",
+			query: "command:cmd term2",
+			expectedConditions: []string{"command LIKE ?", "command LIKE ?"},
+			expectedArgs:      []interface{}{"%cmd%", "%term2%"},
+		},
+		{
+			name: "KQL command field with quoted value",
+			query: `command:"quoted command"`,
+			expectedConditions: []string{"command LIKE ?"},
+			expectedArgs: []interface{}{"%quoted command%"},
+		},
+		{
+			name: "KQL dir field with quoted value",
+			query: `dir:"/quoted/path with spaces"`,
+			expectedConditions: []string{"executing_dir LIKE ?"},
+			expectedArgs: []interface{}{"%\"/quoted/path with spaces\"%"}, // Note: The unquote is for the parser, not for the LIKE value.
+		},
+		{
+			name: "KQL host field with quoted value",
+			query: `host:"quoted hostname"`,
+			expectedConditions: []string{"executing_host LIKE ?"},
+			expectedArgs: []interface{}{"%quoted hostname%"},
+		},
+		{
+            name:  "multiple simple terms and field terms",
+            query: `term1 command:cmd dir:"/some dir/" host:myhost term2`,
+            expectedConditions: []string{
+                "command LIKE ?",
+                "command LIKE ?",
+                "executing_dir LIKE ?",
+                "executing_host LIKE ?",
+                "command LIKE ?",
+            },
+            expectedArgs: []interface{}{
+                "%term1%",
+                "%cmd%",
+                "%\"/some dir/\"%",
+                "%myhost%",
+                "%term2%",
+            },
+        },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hq := &HistoryQuery{} // No manager needed as we are testing Search's direct effect
+
+			var stderrOutput string
+			if tt.expectParseError {
+				stderrOutput = captureStderr(func() {
+					hq.Search(tt.query)
+				})
+			} else {
+				hq.Search(tt.query)
+			}
+
+			if tt.expectParseError {
+				if !strings.Contains(stderrOutput, "KQL parsing error") {
+					t.Errorf("expected KQL parsing error message on stderr, got: %s", stderrOutput)
+				}
+			} else {
+				if strings.Contains(stderrOutput, "KQL parsing error") {
+					t.Errorf("unexpected KQL parsing error message on stderr: %s", stderrOutput)
+				}
+			}
+
+			if !compareStringSlices(hq.conditions, tt.expectedConditions) {
+				t.Errorf("expected conditions %v, got %v", tt.expectedConditions, hq.conditions)
+			}
+			if !compareInterfaceSlices(hq.args, tt.expectedArgs) {
+				t.Errorf("expected args %v, got %v", tt.expectedArgs, hq.args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replaces the simple LIKE-based search in the 'search' subcommand with a KQL-inspired query language. This allows for more advanced searches, including field-specific filtering.

Changes:
- Integrated the 'alecthomas/participle' library for parsing KQL-like queries.
- Updated `internal/history/manager.go` to parse input strings as KQL and translate them into SQL WHERE clauses. Supported fields include `command:`, `dir:` (or `directory:`), and `host:` (or `hostname:`). Simple terms default to searching the command. Multiple terms are ANDed.
- If KQL parsing fails, the search falls back to the previous behavior (a simple LIKE query against the command column).
- Updated the help text in the `search` subcommand's TUI to provide examples of the new KQL syntax.
- Added extensive unit tests for the KQL parsing and SQL condition generation logic in `internal/history/manager_test.go`.