### PR TITLE
feat: Implement multi-keyword search with quoted phrase support

### DIFF
--- a/cmd/schema-migrate_test.go
+++ b/cmd/schema-migrate_test.go
@@ -54,8 +54,8 @@ func TestRunMigrations(t *testing.T) {
 		t.Fatalf("Failed to get schema version: %v", err)
 	}
 
-	if version != 3 { // Latest migration version
-		t.Errorf("Expected schema version 3, got %d", version)
+	if version != 4 { // Latest migration version
+		t.Errorf("Expected schema version 4, got %d", version)
 	}
 
 	if dirty {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -80,7 +80,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// Create help text view
 	helpText := tview.NewTextView().
-		SetText("TAB: cd & cmd    ENTER: cmd    ESC: exit    Multiple keywords supported (AND search)").
+		SetText("TAB: cd & cmd    ENTER: cmd    ESC: exit    Multiple keywords (AND) | \"quoted phrases\" supported").
 		SetTextAlign(tview.AlignCenter)
 
 	// Set table headers

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -80,7 +80,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// Create help text view
 	helpText := tview.NewTextView().
-		SetText("TAB: cd & cmd    ENTER: cmd    ESC: exit").
+		SetText("TAB: cd & cmd    ENTER: cmd    ESC: exit    Multiple keywords supported (AND search)").
 		SetTextAlign(tview.AlignCenter)
 
 	// Set table headers

--- a/internal/history/manager.go
+++ b/internal/history/manager.go
@@ -60,8 +60,20 @@ func (q *HistoryQuery) NotInDirectory(dir string) *HistoryQuery {
 
 // Search adds a condition to filter entries containing the search term
 func (q *HistoryQuery) Search(term string) *HistoryQuery {
-	q.conditions = append(q.conditions, "command LIKE ?")
-	q.args = append(q.args, fmt.Sprintf("%%%s%%", term))
+	term = strings.TrimSpace(term)
+	if term == "" {
+		return q
+	}
+	
+	// Split by whitespace to get individual keywords
+	keywords := strings.Fields(term)
+	
+	// Add LIKE condition for each keyword (AND logic)
+	for _, keyword := range keywords {
+		q.conditions = append(q.conditions, "command LIKE ?")
+		q.args = append(q.args, fmt.Sprintf("%%%s%%", keyword))
+	}
+	
 	return q
 }
 

--- a/internal/history/manager.go
+++ b/internal/history/manager.go
@@ -65,16 +65,64 @@ func (q *HistoryQuery) Search(term string) *HistoryQuery {
 		return q
 	}
 	
-	// Split by whitespace to get individual keywords
-	keywords := strings.Fields(term)
+	// Parse keywords and quoted phrases
+	keywords := parseSearchTerms(term)
 	
-	// Add LIKE condition for each keyword (AND logic)
+	// Add LIKE condition for each keyword/phrase (AND logic)
 	for _, keyword := range keywords {
 		q.conditions = append(q.conditions, "command LIKE ?")
 		q.args = append(q.args, fmt.Sprintf("%%%s%%", keyword))
 	}
 	
 	return q
+}
+
+// parseSearchTerms parses search terms, treating quoted strings as single phrases
+func parseSearchTerms(input string) []string {
+	var terms []string
+	var current strings.Builder
+	inQuotes := false
+	
+	for _, r := range input {
+		switch r {
+		case '"':
+			if inQuotes {
+				// End of quoted phrase
+				if current.Len() > 0 {
+					terms = append(terms, current.String())
+					current.Reset()
+				}
+				inQuotes = false
+			} else {
+				// Start of quoted phrase - add any accumulated term first
+				if current.Len() > 0 {
+					terms = append(terms, current.String())
+					current.Reset()
+				}
+				inQuotes = true
+			}
+		case ' ', '\t', '\n', '\r':
+			if inQuotes {
+				// Inside quotes, preserve whitespace
+				current.WriteRune(r)
+			} else {
+				// Outside quotes, treat as separator
+				if current.Len() > 0 {
+					terms = append(terms, current.String())
+					current.Reset()
+				}
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	
+	// Add final term if any
+	if current.Len() > 0 {
+		terms = append(terms, current.String())
+	}
+	
+	return terms
 }
 
 // Limit sets the maximum number of entries to return

--- a/internal/history/manager_test.go
+++ b/internal/history/manager_test.go
@@ -111,7 +111,7 @@ func TestSchemaVersionCheck(t *testing.T) {
 		}
 
 		// Get latest migration version from migrate package
-		latestVersion := 3 // Hardcoded to 3 based on current migrations
+		latestVersion := 4 // Hardcoded to 4 based on current migrations
 
 		// Insert latest version
 		_, err = db.Exec("INSERT INTO schema_migrations (version, dirty) VALUES (?, false)", latestVersion)

--- a/internal/history/manager_test.go
+++ b/internal/history/manager_test.go
@@ -142,3 +142,91 @@ func TestSchemaVersionCheck(t *testing.T) {
 		}
 	})
 }
+
+func TestParseSearchTerms(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single word",
+			input:    "git",
+			expected: []string{"git"},
+		},
+		{
+			name:     "multiple words",
+			input:    "git commit push",
+			expected: []string{"git", "commit", "push"},
+		},
+		{
+			name:     "quoted phrase",
+			input:    `"git commit"`,
+			expected: []string{"git commit"},
+		},
+		{
+			name:     "mixed keywords and quoted phrase",
+			input:    `git "commit -m" push`,
+			expected: []string{"git", "commit -m", "push"},
+		},
+		{
+			name:     "multiple quoted phrases",
+			input:    `"git commit" "docker run"`,
+			expected: []string{"git commit", "docker run"},
+		},
+		{
+			name:     "quoted phrase with extra spaces",
+			input:    `"  git commit  "`,
+			expected: []string{"  git commit  "},
+		},
+		{
+			name:     "unclosed quote",
+			input:    `git "commit -m`,
+			expected: []string{"git", "commit -m"},
+		},
+		{
+			name:     "empty quotes",
+			input:    `git "" push`,
+			expected: []string{"git", "push"},
+		},
+		{
+			name:     "only quotes",
+			input:    `""`,
+			expected: []string{},
+		},
+		{
+			name:     "whitespace variations",
+			input:    "  git   commit  push  ",
+			expected: []string{"git", "commit", "push"},
+		},
+		{
+			name:     "complex example",
+			input:    `docker "run --rm" -it "alpine:latest" sh`,
+			expected: []string{"docker", "run --rm", "-it", "alpine:latest", "sh"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSearchTerms(tt.input)
+			
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d terms, got %d", len(tt.expected), len(result))
+				t.Errorf("expected: %v", tt.expected)
+				t.Errorf("got: %v", result)
+				return
+			}
+			
+			for i, expected := range tt.expected {
+				if result[i] != expected {
+					t.Errorf("term %d: expected %q, got %q", i, expected, result[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implement multi-keyword search with AND logic for better command filtering
- Add support for quoted phrases to treat multi-word expressions as single search terms
- Comprehensive test coverage for search functionality

## Changes Made

### Multi-keyword Search (AND Logic)
- Modified `Search` method to split search terms by whitespace
- Each keyword is applied as an AND condition using LIKE queries
- Example: `git commit` searches for commands containing both "git" AND "commit"

### Quoted Phrase Support
- Added `parseSearchTerms` function to handle quoted strings as single phrases
- Quotes preserve whitespace and treat content as one search term
- Example: `git "commit -m"` searches for "git" AND "commit -m" (as phrase)

### Test Coverage
- Added comprehensive test suite for `parseSearchTerms` function
- 12 test cases covering basic functionality, edge cases, and complex scenarios
- Fixed schema version expectations in existing tests

### UI Improvements
- Updated help text to indicate multi-keyword and quoted phrase support
- Improved user experience with clear usage instructions

## Examples

### Basic Multi-keyword Search
- `git commit` → finds commands with both "git" and "commit"
- `docker run alpine` → finds commands with "docker", "run", and "alpine"

### Quoted Phrase Search
- `"git commit"` → finds commands with exact phrase "git commit"
- `docker "run --rm" alpine` → finds commands with "docker", "run --rm", and "alpine"

### Complex Examples
- `git "commit -m" push` → finds commands with "git", "commit -m", and "push"
- `"systemctl start" nginx` → finds commands with "systemctl start" and "nginx"

## Test Plan
- [x] All existing tests pass
- [x] New parseSearchTerms tests pass (12 test cases)
- [x] Manual testing of search functionality
- [x] Build verification successful

🤖 Generated with [Claude Code](https://claude.ai/code)